### PR TITLE
fix: resolve failing authentication security tests in CI

### DIFF
--- a/tests/authentication_security_test.go
+++ b/tests/authentication_security_test.go
@@ -110,6 +110,9 @@ func (suite *AuthenticationSecurityTestSuite) SetupTest() {
 		ctx := context.Background()
 		suite.redisClient.FlushDB(ctx)
 	}
+	
+	// Ensure test user exists before each test
+	suite.createTestUser()
 }
 
 func (suite *AuthenticationSecurityTestSuite) setupRouter() {
@@ -188,7 +191,11 @@ func (suite *AuthenticationSecurityTestSuite) createTestUser() {
 		PasswordHash: hashedPassword,
 		Role:         role,
 	})
-	require.NoError(suite.T(), err)
+	if err != nil {
+		// Log the error for debugging but don't fail the test immediately
+		suite.T().Logf("Failed to create test user: %v", err)
+		require.NoError(suite.T(), err, "Failed to create test user in createTestUser")
+	}
 }
 
 // Test: Brute force attack protection

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -56,13 +56,15 @@ func cleanupTestData(t *testing.T, pool *pgxpool.Pool) {
 	ctx := context.Background()
 
 	// Clean test data in reverse dependency order
-	_, _ = pool.Exec(ctx, "DELETE FROM audit_logs WHERE table_name LIKE 'test_%' OR user_id IN (SELECT id FROM users WHERE username LIKE 'test%')")
+	// Note: We preserve 'testuser' for security tests, but clean other test users
+	_, _ = pool.Exec(ctx, "DELETE FROM audit_logs WHERE table_name LIKE 'test_%' OR user_id IN (SELECT id FROM users WHERE username LIKE 'test%' AND username != 'testuser')")
 	_, _ = pool.Exec(ctx, "DELETE FROM notifications WHERE title LIKE 'Test%'")
 	_, _ = pool.Exec(ctx, "DELETE FROM reservations WHERE id > 1000000 OR student_id IN (SELECT id FROM students WHERE student_id LIKE 'TEST_%' OR student_id LIKE 'STU%')")
 	_, _ = pool.Exec(ctx, "DELETE FROM transactions WHERE id > 1000000 OR student_id IN (SELECT id FROM students WHERE student_id LIKE 'TEST_%' OR student_id LIKE 'STU%')")
 	_, _ = pool.Exec(ctx, "DELETE FROM books WHERE book_id LIKE 'TEST_%' OR book_id LIKE 'BK%'")
 	_, _ = pool.Exec(ctx, "DELETE FROM students WHERE student_id LIKE 'TEST_%' OR student_id LIKE 'STU%'")
-	_, _ = pool.Exec(ctx, "DELETE FROM users WHERE username LIKE 'test%'")
+	// Preserve 'testuser' for security tests, but clean other test users  
+	_, _ = pool.Exec(ctx, "DELETE FROM users WHERE username LIKE 'test%' AND username != 'testuser'")
 }
 
 // testLogger creates a test logger


### PR DESCRIPTION
## Summary
Fixes failing authentication security tests that were causing CI pipeline failures.

## Changes Made
- Fixed user cleanup logic to preserve `testuser` needed for security tests
- Added user recreation in `SetupTest()` to ensure test reliability  
- Improved error handling and logging in `createTestUser()` method

## Root Cause
The tests were failing because the cleanup function was deleting the `testuser` that authentication security tests depend on. The cleanup query `DELETE FROM users WHERE username LIKE 'test%'` was removing the critical test user, causing "no rows in result set" errors.

## Solution
- Modified cleanup to preserve specific user: `username LIKE 'test%' AND username != 'testuser'`
- Added redundant user creation in `SetupTest()` for additional safety
- Enhanced error logging for better debugging

## Tests Fixed
- ✅ Brute force protection tests
- ✅ JWT token security validation  
- ✅ Refresh token security checks
- ✅ Session management security tests

## Test Results
All authentication security tests now pass (verified locally):
- `TestBruteForceProtection/Multiple_failed_login_attempts_should_be_rate_limited`
- `TestJWTTokenSecurity/Token_tampering_should_be_detected` 
- `TestJWTTokenSecurity/Token_without_Bearer_prefix_should_be_rejected`
- `TestRefreshTokenSecurity/Refresh_token_should_work_properly`
- `TestSessionManagementSecurity/Token_blacklisting_should_work`
- `TestSessionManagementSecurity/Concurrent_session_validation`

## Impact
- No breaking changes
- All existing tests still pass
- CI pipeline should now pass successfully